### PR TITLE
Fix Dockerfile comment

### DIFF
--- a/Hepsifly.API/Dockerfile
+++ b/Hepsifly.API/Dockerfile
@@ -1,5 +1,5 @@
-#See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
-
+# See https://aka.ms/customizecontainer for information on customizing the container.
+# This Dockerfile builds the production container, which Visual Studio also uses for faster debugging.
 FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
 WORKDIR /app
 EXPOSE 80


### PR DESCRIPTION
## Summary
- update comment in Hepsifly.API Dockerfile

## Testing
- `dotnet build Hepsifly.sln` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6847f196d2588323a070c67c3460a81f